### PR TITLE
Fix type instability in localcolumns()

### DIFF
--- a/src/MPIQR.jl
+++ b/src/MPIQR.jl
@@ -24,7 +24,7 @@ function validblocksizes(numcols::Integer, commsize::Integer)::Vector{Int}
 end
 
 function localcolumns(rnk, n, blocksize, commsize)
-  output = Vector{Int}(vcat(collect(partition(collect(1:n), blocksize))[rnk + 1:commsize:end]...))
+  output = reduce(vcat, collect(partition(collect(1:n), blocksize))[rnk + 1:commsize:end])
   @assert isempty(output) || minimum(output) >= 1
   @assert isempty(output) || maximum(output) <= n
   @assert issorted(output)

--- a/src/MPIQR.jl
+++ b/src/MPIQR.jl
@@ -24,7 +24,7 @@ function validblocksizes(numcols::Integer, commsize::Integer)::Vector{Int}
 end
 
 function localcolumns(rnk, n, blocksize, commsize)
-  output = reduce(vcat, collect(partition(collect(1:n), blocksize))[rnk + 1:commsize:end])
+  output = reduce(vcat, collect(partition(collect(1:n), blocksize))[rnk + 1:commsize:end]; init=Int[])
   @assert isempty(output) || minimum(output) >= 1
   @assert isempty(output) || maximum(output) <= n
   @assert issorted(output)


### PR DESCRIPTION
Use `reduce()` instead of splatting a vector, suggested by https://discourse.julialang.org/t/type-stability-problem-vcat-tuple-and-function/53862/3